### PR TITLE
Streaming inputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,9 @@ import ReleaseTransformations._
 
 name := "akka-xlsx"
 
-lazy val AkkaVersion       = "2.5.12"
-lazy val AlpakkaXmlVersion = "0.19"
+lazy val AkkaVersion        = "2.5.12"
+lazy val AkkaContribVersion = "0.9"
+lazy val AlpakkaXmlVersion  = "0.19"
 
 lazy val commonSettings = Seq(
   updateOptions := updateOptions.value.withGigahorse(false),
@@ -30,6 +31,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "com.typesafe.akka"  %% "akka-stream"             % AkkaVersion,
       "com.lightbend.akka" %% "akka-stream-alpakka-xml" % AlpakkaXmlVersion,
+      "com.typesafe.akka" %% "akka-stream-contrib"      % AkkaContribVersion,
       "com.typesafe.akka"  %% "akka-stream-testkit"     % AkkaVersion % Test
     )
   )

--- a/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
@@ -16,7 +16,6 @@ object SstStreamer {
   private final val EntryName = "xl/sharedStrings.xml"
   private val defaultSink = Sink.fold[Map[Int, String], (Int, String)](Map.empty)((v1, v2) => v1 + v2)
 
-
   def readSst(zipFile: ZipFile)(implicit materializer: Materializer): Future[Map[Int, String]] = {
     readSst(zipFile, defaultSink)
   }
@@ -31,7 +30,6 @@ object SstStreamer {
     }
   }
 
-
   def readSst(source: Iterable[(ZipEntryData, ByteString)])(implicit materializer: Materializer): Future[Map[Int, String]] = {
     readSst(source, defaultSink)
   }
@@ -41,7 +39,7 @@ object SstStreamer {
       mapSink: Sink[(Int, String), Future[Map[Int, String]]]
   )(implicit materializer: Materializer): Future[Map[Int, String]] = {
     read(
-      Source.fromIterator(() => source.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }.iterator),
+      Source.fromIterator(() => source.iterator.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }),
       mapSink
     )
   }

--- a/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
@@ -9,12 +9,13 @@ import akka.stream.contrib.ZipInputStreamSource.ZipEntryData
 import akka.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
 import akka.util.ByteString
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 object SstStreamer {
 
   private final val EntryName = "xl/sharedStrings.xml"
-  private val defaultSink = Sink.fold[Map[Int, String], (Int, String)](Map.empty)((v1, v2) => v1 + v2)
+  private[xlsx] val defaultSink = Sink.seq[(Int, String)].mapMaterializedValue(_.map(_.toMap)(ExecutionContext.fromExecutor(_.run())))
+
 
   def readSst(zipFile: ZipFile)(implicit materializer: Materializer): Future[Map[Int, String]] = {
     readSst(zipFile, defaultSink)

--- a/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
@@ -24,10 +24,9 @@ object SstStreamer {
       zipFile: ZipFile,
       mapSink: Sink[(Int, String), Future[Map[Int, String]]]
   )(implicit materializer: Materializer): Future[Map[Int, String]] = {
-    Option(zipFile.getEntry(EntryName)) match {
-      case Some(entry) => read(StreamConverters.fromInputStream(() => zipFile.getInputStream(entry)), mapSink)
-      case None        => Source.empty[(Int, String)].toMat(mapSink)(Keep.right).run()
-    }
+    Option(zipFile.getEntry(EntryName))
+      .map(entry => read(StreamConverters.fromInputStream(() => zipFile.getInputStream(entry)), mapSink))
+      .getOrElse(Future.successful(Map.empty))
   }
 
   def readSst(source: Iterable[(ZipEntryData, ByteString)])(implicit materializer: Materializer): Future[Map[Int, String]] = {

--- a/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
@@ -1,12 +1,13 @@
 package akka.stream.alpakka.xlsx
 
-import java.io.InputStream
 import java.util.zip.ZipFile
 
 import akka.stream.Materializer
-import akka.stream.alpakka.xml.{ EndElement, ParseEvent, StartElement }
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.scaladsl.{ Keep, Sink, Source, StreamConverters }
+import akka.stream.alpakka.xml.{EndElement, ParseEvent, StartElement}
+import akka.stream.contrib.ZipInputStreamSource.ZipEntryData
+import akka.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
+import akka.util.ByteString
 
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -14,26 +15,45 @@ import scala.util.Try
 
 object StyleStreamer {
 
-  def readStyles(file: ZipFile)(implicit materializer: Materializer): Future[Map[Int, Int]] = {
-    readStyles(file, Sink.fold(Map.empty[Int, Int])((v1, v2) => v1 + v2))
+  private final val EntryName = "xl/styles.xml"
+  private val defaultSink = Sink.fold[Map[Int, Int], (Int, Int)](Map.empty)((v1, v2) => v1 + v2)
+
+
+  def readStyles(zipFile: ZipFile)(implicit materializer: Materializer): Future[Map[Int, Int]] = {
+    readStyles(zipFile, defaultSink)
   }
 
   def readStyles(
-      file: ZipFile,
+      zipFile: ZipFile,
       mapSink: Sink[(Int, Int), Future[Map[Int, Int]]]
   )(implicit materializer: Materializer): Future[Map[Int, Int]] = {
-    Option(file.getEntry("xl/styles.xml")) match {
-      case Some(entry) => read(file.getInputStream(entry), mapSink)
+    Option(zipFile.getEntry(EntryName)) match {
+      case Some(entry) => read(StreamConverters.fromInputStream(() => zipFile.getInputStream(entry)), mapSink)
       case None        => Source.empty[(Int, Int)].toMat(mapSink)(Keep.right).run()
     }
   }
 
+
+  def readStyles(source: Iterable[(ZipEntryData, ByteString)])(implicit materializer: Materializer): Future[Map[Int, Int]] = {
+    readStyles(source, defaultSink)
+  }
+
+  def readStyles(
+      source: Iterable[(ZipEntryData, ByteString)],
+      mapSink: Sink[(Int, Int), Future[Map[Int, Int]]]
+  )(implicit materializer: Materializer): Future[Map[Int, Int]] = {
+    read(
+      Source.fromIterator(() => source.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }.iterator),
+      mapSink
+    )
+  }
+
+
   private def read(
-      inputStream: InputStream,
+      inputSource: Source[ByteString, _],
       mapSink: Sink[(Int, Int), Future[Map[Int, Int]]]
   )(implicit materializer: Materializer) = {
-    StreamConverters
-      .fromInputStream(() => inputStream)
+    inputSource
       .via(XmlParsing.parser)
       .statefulMapConcat[(Int, Int)](() => {
         val numFmtMapping: mutable.Map[Int, Int] = mutable.Map.empty

--- a/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
@@ -10,13 +10,13 @@ import akka.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
 import akka.util.ByteString
 
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 object StyleStreamer {
 
   private final val EntryName = "xl/styles.xml"
-  private val defaultSink = Sink.fold[Map[Int, Int], (Int, Int)](Map.empty)((v1, v2) => v1 + v2)
+  private[xlsx] val defaultSink = Sink.seq[(Int, Int)].mapMaterializedValue(_.map(_.toMap)(ExecutionContext.fromExecutor(_.run())))
 
   def readStyles(zipFile: ZipFile)(implicit materializer: Materializer): Future[Map[Int, Int]] = {
     readStyles(zipFile, defaultSink)

--- a/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
@@ -26,10 +26,9 @@ object StyleStreamer {
       zipFile: ZipFile,
       mapSink: Sink[(Int, Int), Future[Map[Int, Int]]]
   )(implicit materializer: Materializer): Future[Map[Int, Int]] = {
-    Option(zipFile.getEntry(EntryName)) match {
-      case Some(entry) => read(StreamConverters.fromInputStream(() => zipFile.getInputStream(entry)), mapSink)
-      case None        => Source.empty[(Int, Int)].toMat(mapSink)(Keep.right).run()
-    }
+    Option(zipFile.getEntry(EntryName))
+      .map(entry => read(StreamConverters.fromInputStream(() => zipFile.getInputStream(entry)), mapSink))
+      .getOrElse(Future.successful(Map.empty))
   }
 
   def readStyles(source: Iterable[(ZipEntryData, ByteString)])(implicit materializer: Materializer): Future[Map[Int, Int]] = {

--- a/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
@@ -18,7 +18,6 @@ object StyleStreamer {
   private final val EntryName = "xl/styles.xml"
   private val defaultSink = Sink.fold[Map[Int, Int], (Int, Int)](Map.empty)((v1, v2) => v1 + v2)
 
-
   def readStyles(zipFile: ZipFile)(implicit materializer: Materializer): Future[Map[Int, Int]] = {
     readStyles(zipFile, defaultSink)
   }
@@ -33,7 +32,6 @@ object StyleStreamer {
     }
   }
 
-
   def readStyles(source: Iterable[(ZipEntryData, ByteString)])(implicit materializer: Materializer): Future[Map[Int, Int]] = {
     readStyles(source, defaultSink)
   }
@@ -43,7 +41,7 @@ object StyleStreamer {
       mapSink: Sink[(Int, Int), Future[Map[Int, Int]]]
   )(implicit materializer: Materializer): Future[Map[Int, Int]] = {
     read(
-      Source.fromIterator(() => source.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }.iterator),
+      Source.fromIterator(() => source.iterator.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }),
       mapSink
     )
   }

--- a/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 object StyleStreamer {
 
   private final val EntryName = "xl/styles.xml"
-  private[xlsx] val defaultSink = Sink.seq[(Int, Int)].mapMaterializedValue(_.map(_.toMap)(ExecutionContext.fromExecutor(_.run())))
+  private val defaultSink = Sink.seq[(Int, Int)].mapMaterializedValue(_.map(_.toMap)(ExecutionContext.fromExecutor(_.run())))
 
   def readStyles(zipFile: ZipFile)(implicit materializer: Materializer): Future[Map[Int, Int]] = {
     readStyles(zipFile, defaultSink)

--- a/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
@@ -25,10 +25,9 @@ object WorkbookStreamer {
   }
 
   def readWorkbook(source: Iterable[(ZipEntryData, ByteString)])(implicit materializer: Materializer): Future[Map[String, Int]] = {
-    Option(source.iterator.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes })
-      .filter(_.nonEmpty)
-      .map(entry => read(Source.fromIterator(() => entry)))
-      .getOrElse(Future.failed(new FileNotFoundException(WorkbookNotFoundExceptionMsg)))
+    val filteredIterator = source.iterator.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }
+    if (filteredIterator.isEmpty) Future.failed(new FileNotFoundException(WorkbookNotFoundExceptionMsg))
+    else read(Source.fromIterator(() => filteredIterator))
   }
 
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
@@ -17,7 +17,6 @@ object WorkbookStreamer {
   private final val EntryName = "xl/workbook.xml"
   private final val InvalidFileExceptionMsg = "Invalid xlsx file - no workbook entry"
 
-
   def readWorkbook(zipFile: ZipFile)(implicit materializer: Materializer): Future[Map[String, Int]] = {
     Option(zipFile.getEntry(EntryName)) match {
       case Some(entry) => read(StreamConverters.fromInputStream(() => zipFile.getInputStream(entry)))
@@ -25,10 +24,9 @@ object WorkbookStreamer {
     }
   }
 
-
   def readWorkbook(source: Iterable[(ZipEntryData, ByteString)])(implicit materializer: Materializer): Future[Map[String, Int]] = {
     read(Source.fromIterator(() => {
-      val filteredIterator = source.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }.iterator
+      val filteredIterator = source.iterator.collect { case (zipEntry, bytes) if zipEntry.name == EntryName => bytes }
       if (filteredIterator.isEmpty) throw new Exception(InvalidFileExceptionMsg)
       filteredIterator
     }))

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -18,14 +18,12 @@ import scala.util.Try
 
 object XlsxParsing {
 
-  private val defaultSink = Sink.fold[Map[Int, String], (Int, String)](Map.empty)((v1, v2) => v1 + v2)
-
   def fromZipFile(file: ZipFile, sheetId: Int)(implicit materializer: Materializer): Source[Row, NotUsed] = {
-    fromZipFile(file, sheetId, defaultSink)
+    fromZipFile(file, sheetId, SstStreamer.defaultSink)
   }
 
   def fromZipFile(file: ZipFile, sheetName: String)(implicit materializer: Materializer): Source[Row, NotUsed] = {
-    fromZipFile(file, sheetName, defaultSink)
+    fromZipFile(file, sheetName, SstStreamer.defaultSink)
   }
 
   def fromZipFile(
@@ -48,14 +46,14 @@ object XlsxParsing {
       source: Source[ByteString, _],
       sheetId: Int
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
-    fromStream(source, sheetId, defaultSink)
+    fromStream(source, sheetId, SstStreamer.defaultSink)
   }
 
   def fromStream(
       source: Source[ByteString, _],
       sheetName: String
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
-    fromStream(source, sheetName, defaultSink)
+    fromStream(source, sheetName, SstStreamer.defaultSink)
   }
 
   def fromStream(

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -20,7 +20,6 @@ object XlsxParsing {
 
   private val defaultSink = Sink.fold[Map[Int, String], (Int, String)](Map.empty)((v1, v2) => v1 + v2)
 
-
   def fromZipFile(file: ZipFile, sheetId: Int)(implicit materializer: Materializer): Source[Row, NotUsed] = {
     fromZipFile(file, sheetId, defaultSink)
   }
@@ -44,7 +43,6 @@ object XlsxParsing {
   )(implicit materializer: Materializer): Source[Row, NotUsed] = {
     readFromFile(file, SheetType.Name(sheetName), sstSink)
   }
-
 
   def fromStream(
       source: Source[ByteString, _],
@@ -128,7 +126,6 @@ object XlsxParsing {
 
   private def worksheetNotFoundExceptionMsg(sheetType: SheetType) = s"Workbook sheet $sheetType could not be found"
 
-
   private def readFromFile(
       file: ZipFile,
       sheetType: SheetType,
@@ -167,7 +164,7 @@ object XlsxParsing {
         val optionalSheetName = sheetEntryName(sheetType, workbook)
         zipEntries.map { source =>
           Source.fromIterator(() => {
-            val filteredIterator = source.collect { case (zipEntry, bytes) if optionalSheetName.contains(zipEntry.name) => bytes }.iterator
+            val filteredIterator = source.iterator.collect { case (zipEntry, bytes) if optionalSheetName.contains(zipEntry.name) => bytes }
             if (filteredIterator.isEmpty) throw new FileNotFoundException(worksheetNotFoundExceptionMsg(sheetType))
             filteredIterator
           })

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -162,9 +162,9 @@ object XlsxParsing {
         val optionalSheetName = sheetEntryName(sheetType, workbook)
         zipEntries.map { source =>
           Source.fromIterator(() => {
-            Option(source.iterator.collect { case (zipEntry, bytes) if optionalSheetName.contains(zipEntry.name) => bytes })
-              .filter(_.nonEmpty)
-              .getOrElse(throw new FileNotFoundException(worksheetNotFoundExceptionMsg(sheetType)))
+            val filteredIterator = source.iterator.collect { case (zipEntry, bytes) if optionalSheetName.contains(zipEntry.name) => bytes }
+            if (filteredIterator.isEmpty) throw new FileNotFoundException(worksheetNotFoundExceptionMsg(sheetType))
+            filteredIterator
           })
         }
       }

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -1,34 +1,32 @@
 package akka.stream.alpakka.xlsx
 
-import java.io.FileNotFoundException
-import java.util.zip.ZipFile
+import java.io.{FileNotFoundException, PipedInputStream, PipedOutputStream}
+import java.util.zip.{ZipFile, ZipInputStream}
 
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.alpakka.xml.{ Characters, EndElement, ParseEvent, StartElement }
-import akka.stream.scaladsl.{ Sink, Source, StreamConverters }
+import akka.stream.alpakka.xml.{Characters, EndElement, ParseEvent, StartElement}
+import akka.stream.contrib.ZipInputStreamSource
+import akka.stream.contrib.ZipInputStreamSource.ZipEntryData
+import akka.stream.scaladsl.{Sink, Source, StreamConverters}
+import akka.util.ByteString
 
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 object XlsxParsing {
 
+  private val defaultSink = Sink.fold[Map[Int, String], (Int, String)](Map.empty)((v1, v2) => v1 + v2)
+
+
   def fromZipFile(file: ZipFile, sheetId: Int)(implicit materializer: Materializer): Source[Row, NotUsed] = {
-    fromZipFile(
-      file,
-      sheetId,
-      Sink.fold[Map[Int, String], (Int, String)](Map.empty[Int, String])((v1, v2) => v1 + v2)
-    )
+    fromZipFile(file, sheetId, defaultSink)
   }
 
   def fromZipFile(file: ZipFile, sheetName: String)(implicit materializer: Materializer): Source[Row, NotUsed] = {
-    fromZipFile(
-      file,
-      sheetName,
-      Sink.fold[Map[Int, String], (Int, String)](Map.empty[Int, String])((v1, v2) => v1 + v2)
-    )
+    fromZipFile(file, sheetName, defaultSink)
   }
 
   def fromZipFile(
@@ -36,7 +34,7 @@ object XlsxParsing {
       sheetId: Int,
       sstSink: Sink[(Int, String), Future[Map[Int, String]]]
   )(implicit materializer: Materializer): Source[Row, NotUsed] = {
-    read(file, SheetType.Id(sheetId), sstSink)
+    readFromFile(file, SheetType.Id(sheetId), sstSink)
   }
 
   def fromZipFile(
@@ -44,8 +42,50 @@ object XlsxParsing {
       sheetName: String,
       sstSink: Sink[(Int, String), Future[Map[Int, String]]]
   )(implicit materializer: Materializer): Source[Row, NotUsed] = {
-    read(file, SheetType.Name(sheetName), sstSink)
+    readFromFile(file, SheetType.Name(sheetName), sstSink)
   }
+
+
+  def fromStream(
+      source: Source[ByteString, _],
+      sheetId: Int
+  )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
+    fromStream(source, sheetId, defaultSink)
+  }
+
+  def fromStream(
+      source: Source[ByteString, _],
+      sheetName: String
+  )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
+    fromStream(source, sheetName, defaultSink)
+  }
+
+  def fromStream(
+      source: Source[ByteString, _],
+      sheetId: Int,
+      sstSink: Sink[(Int, String), Future[Map[Int, String]]]
+  )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
+    fromStream(source, SheetType.Id(sheetId), sstSink)
+  }
+
+  def fromStream(
+      source: Source[ByteString, _],
+      sheetName: String,
+      sstSink: Sink[(Int, String), Future[Map[Int, String]]]
+  )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
+    fromStream(source, SheetType.Name(sheetName), sstSink)
+  }
+
+  private def fromStream(
+      source: Source[ByteString, _],
+      sheetType: SheetType,
+      sstSink: Sink[(Int, String), Future[Map[Int, String]]]
+  )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
+    val nextStepInputStream = new PipedInputStream()
+    source.to(StreamConverters.fromOutputStream(() => new PipedOutputStream(nextStepInputStream))).run()
+    readFromStream(ZipInputStreamSource(() => new ZipInputStream(nextStepInputStream)), sheetType, sstSink)
+  }
+
 
   private def nillable(s: => Any): List[Row] = {
     s
@@ -77,97 +117,129 @@ object XlsxParsing {
     }
   }
 
-  private def getSheetStream(file: ZipFile, typ: SheetType, workbook: Workbook) = {
-    val io = typ match {
-      case SheetType.Name(name) =>
-        workbook.sheets.get(name).flatMap(v => Option(file.getEntry(s"xl/worksheets/sheet$v.xml")))
-      case SheetType.Id(id) =>
-        Option(file.getEntry(s"xl/worksheets/sheet$id.xml"))
-    }
-    io match {
-      case Some(entry) => file.getInputStream(entry)
-      case None        => throw new FileNotFoundException(s"workbook sheet $typ could not be found")
+  private def sheetEntryName(sheetType: SheetType, workbook: Workbook) = {
+    sheetType match {
+      case SheetType.Name(sheetName) =>
+        workbook.sheets.get(sheetName).map(sheetId => s"xl/worksheets/sheet$sheetId.xml")
+      case SheetType.Id(sheetId) =>
+        Option(s"xl/worksheets/sheet$sheetId.xml")
     }
   }
 
-  private def read(
+  private def worksheetNotFoundExceptionMsg(sheetType: SheetType) = s"Workbook sheet $sheetType could not be found"
+
+
+  private def readFromFile(
       file: ZipFile,
-      typ: SheetType,
+      sheetType: SheetType,
       sstSink: Sink[(Int, String), Future[Map[Int, String]]]
   )(implicit materializer: Materializer) = {
-    Source
+    val workbookSource = Source
       .fromFuture(SstStreamer.readSst(file, sstSink))
       .flatMapConcat(sst => Source.fromFuture(StyleStreamer.readStyles(file)).map((sst, _)))
-      .flatMapConcat {
-        case (sst, styles) =>
-          Source.fromFuture(WorkbookStreamer.readWorkbook(file)).map(sheets => Workbook(sst, sheets, styles))
+      .flatMapConcat { case (sst, styles) =>
+        Source.fromFuture(WorkbookStreamer.readWorkbook(file)).map(sheets => Workbook(sst, sheets, styles))
       }
-      .flatMapConcat { workbook =>
-        StreamConverters
-          .fromInputStream(() => getSheetStream(file, typ, workbook))
-          .via(XmlParsing.parser)
-          .statefulMapConcat[Row](() => {
-            var insideRow: Boolean                   = false
-            var insideCol: Boolean                   = false
-            var insideValue: Boolean                 = false
-            var insideFormula: Boolean               = false
-            var cellType: Option[CellType]           = None
-            var lastContent: Option[String]          = None
-            var lastFormula: Option[String]          = None
-            var cellList: mutable.TreeMap[Int, Cell] = mutable.TreeMap.empty
-            var rowNum                               = 1
-            var cellNum                              = 1
-            var ref: Option[CellReference]           = None
-            var numFmtId: Option[Int]                = None
+    val sheetSourceCreator =
+      (workbook: Workbook) => StreamConverters.fromInputStream(() =>
+        sheetEntryName(sheetType, workbook).flatMap(sheet => Option(file.getEntry(sheet))) match {
+          case Some(entry) => file.getInputStream(entry)
+          case None => throw new FileNotFoundException(worksheetNotFoundExceptionMsg(sheetType))
+        }
+      )
+    read(workbookSource, sheetSourceCreator)
+  }
 
-            (data: ParseEvent) =>
-              data match {
-                case StartElement("row", _, _, _, _) => nillable(insideRow = true)
-                case StartElement("c", attrs, _, _, _) if insideRow =>
-                  nillable({
-                    ref = CellReference.parseRef(attrs)
-                    numFmtId = attrs.find(_.name == "s").flatMap(a => Try(Integer.parseInt(a.value)).toOption)
-                    cellType = attrs.find(_.name == "t").map(a => CellType.parse(a.value))
-                    insideCol = true
-                  })
-                case StartElement("v", _, _, _, _) if insideCol =>
-                  nillable({ insideValue = true })
-                case StartElement("f", _, _, _, _) if insideCol =>
-                  nillable(insideFormula = true)
-                case Characters(text) if insideValue =>
-                  nillable(lastContent = Some(lastContent.map(_ + text).getOrElse(text)))
-                case Characters(text) if insideFormula =>
-                  nillable({
-                    lastFormula = Some(lastFormula.map(_ + text).getOrElse(text))
-                  })
-                case EndElement("v") if insideValue =>
-                  nillable({ insideValue = false })
-                case EndElement("f") if insideFormula =>
-                  nillable(insideFormula = false)
-                case EndElement("c") if insideCol =>
-                  nillable({
-                    val simpleRef = ref.getOrElse(CellReference("", cellNum, rowNum))
-                    val cell      = buildCell(cellType, lastContent, lastFormula, numFmtId, workbook, simpleRef)
-                    cellList += (simpleRef.colNum -> cell)
-                    numFmtId = None
-                    ref = None
-                    cellNum += 1
-                    insideCol = false
-                    cellType = None
-                    lastContent = None
-                    lastFormula = None
-                  })
-                case EndElement("row") if insideRow =>
-                  val ret = new Row(rowNum, cellList)
-                  rowNum += 1
-                  cellNum = 1
-                  cellList = mutable.TreeMap.empty
-                  insideRow = false
-                  ret :: Nil
-                case _ => Nil // ignore unused stuff
-              }
-          })
+  private def readFromStream(
+      source: Source[(ZipEntryData, ByteString), Future[Long]],
+      sheetType: SheetType,
+      sstSink: Sink[(Int, String), Future[Map[Int, String]]]
+  )(implicit materializer: Materializer, executionContext: ExecutionContext) = {
+    val zipEntries = source.runWith(Sink.seq)
+    val workbookSource = Source
+      .fromFuture(zipEntries.flatMap(SstStreamer.readSst(_, sstSink)))
+      .flatMapConcat(sst => Source.fromFuture(zipEntries.flatMap(StyleStreamer.readStyles)).map((sst, _)))
+      .flatMapConcat { case (sst, styles) =>
+        Source.fromFuture(zipEntries.flatMap(WorkbookStreamer.readWorkbook)).map(sheets => Workbook(sst, sheets, styles))
       }
+    val sheetSourceCreator =
+      (workbook: Workbook) => Source.fromFutureSource {
+        val optionalSheetName = sheetEntryName(sheetType, workbook)
+        zipEntries.map { source =>
+          Source.fromIterator(() => {
+            val filteredIterator = source.collect { case (zipEntry, bytes) if optionalSheetName.contains(zipEntry.name) => bytes }.iterator
+            if (filteredIterator.isEmpty) throw new FileNotFoundException(worksheetNotFoundExceptionMsg(sheetType))
+            filteredIterator
+          })
+        }
+      }
+    read(workbookSource, sheetSourceCreator)
+  }
+
+  private def read(workbookSource: Source[Workbook, _], sheetSourceCreator: Workbook => Source[ByteString, _]) = {
+    workbookSource.flatMapConcat { workbook =>
+      sheetSourceCreator(workbook)
+        .via(XmlParsing.parser)
+        .statefulMapConcat[Row](() => {
+          var insideRow: Boolean = false
+          var insideCol: Boolean = false
+          var insideValue: Boolean = false
+          var insideFormula: Boolean = false
+          var cellType: Option[CellType] = None
+          var lastContent: Option[String] = None
+          var lastFormula: Option[String] = None
+          var cellList: mutable.TreeMap[Int, Cell] = mutable.TreeMap.empty
+          var rowNum = 1
+          var cellNum = 1
+          var ref: Option[CellReference] = None
+          var numFmtId: Option[Int] = None
+
+          (data: ParseEvent) =>
+            data match {
+              case StartElement("row", _, _, _, _) => nillable(insideRow = true)
+              case StartElement("c", attrs, _, _, _) if insideRow =>
+                nillable({
+                  ref = CellReference.parseRef(attrs)
+                  numFmtId = attrs.find(_.name == "s").flatMap(a => Try(Integer.parseInt(a.value)).toOption)
+                  cellType = attrs.find(_.name == "t").map(a => CellType.parse(a.value))
+                  insideCol = true
+                })
+              case StartElement("v", _, _, _, _) if insideCol =>
+                nillable({ insideValue = true })
+              case StartElement("f", _, _, _, _) if insideCol =>
+                nillable(insideFormula = true)
+              case Characters(text) if insideValue =>
+                nillable(lastContent = Some(lastContent.map(_ + text).getOrElse(text)))
+              case Characters(text) if insideFormula =>
+                nillable({ lastFormula = Some(lastFormula.map(_ + text).getOrElse(text)) })
+              case EndElement("v") if insideValue =>
+                nillable({ insideValue = false })
+              case EndElement("f") if insideFormula =>
+                nillable(insideFormula = false)
+              case EndElement("c") if insideCol =>
+                nillable({
+                  val simpleRef = ref.getOrElse(CellReference("", cellNum, rowNum))
+                  val cell = buildCell(cellType, lastContent, lastFormula, numFmtId, workbook, simpleRef)
+                  cellList += (simpleRef.colNum -> cell)
+                  numFmtId = None
+                  ref = None
+                  cellNum += 1
+                  insideCol = false
+                  cellType = None
+                  lastContent = None
+                  lastFormula = None
+                })
+              case EndElement("row") if insideRow =>
+                val ret = new Row(rowNum, cellList)
+                rowNum += 1
+                cellNum = 1
+                cellList = mutable.TreeMap.empty
+                insideRow = false
+                ret :: Nil
+              case _ => Nil // ignore unused stuff
+            }
+        })
+    }
   }
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.8-SNAPSHOT"
+version in ThisBuild := "0.0.8-AV1"


### PR DESCRIPTION
Things done:
1. A family of `fromStream` methods accepting the `Source[ByteString, _]` input added.
2. Common processing logic for both `ZipFile` and `Source[ByteString, _` inputs extracted.
3. Cleanup.
