### PR TITLE
Fix race between pipe connection and reading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "akka-xlsx"
 
 lazy val AlpakkaXmlVersion = "3.0.3"
-
+lazy val AkkaTestkitVersion = "2.6.16"
 lazy val ScalatestVersion = "3.2.3"
 lazy val ScalatestPlusVersion = "3.2.3.0"
 lazy val ScalacheckVersion = "1.15.2"
@@ -28,6 +28,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "com.lightbend.akka" %% "akka-stream-alpakka-xml" % AlpakkaXmlVersion,
     ) ++ Seq(
+      "com.typesafe.akka" %% "akka-stream-testkit" % AkkaTestkitVersion,
       "org.scalatest" %% "scalatest" % ScalatestVersion,
       "org.scalatestplus" %% "scalacheck-1-15" % ScalatestPlusVersion,
       "org.scalacheck" %% "scalacheck" % ScalacheckVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 name := "akka-xlsx"
 
-lazy val AkkaVersion = "2.6.16"
-lazy val AkkaContribVersion = "0.11"
 lazy val AlpakkaXmlVersion = "3.0.3"
 
 lazy val ScalatestVersion = "3.2.3"
@@ -29,9 +27,7 @@ lazy val root = (project in file("."))
   .settings(commonSettings ++ Seq(
     libraryDependencies ++= Seq(
       "com.lightbend.akka" %% "akka-stream-alpakka-xml" % AlpakkaXmlVersion,
-      "com.typesafe.akka" %% "akka-stream-contrib" % AkkaContribVersion,
     ) ++ Seq(
-      "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
       "org.scalatest" %% "scalatest" % ScalatestVersion,
       "org.scalatestplus" %% "scalacheck-1-15" % ScalatestPlusVersion,
       "org.scalacheck" %% "scalacheck" % ScalacheckVersion,

--- a/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
@@ -1,11 +1,10 @@
 package akka.stream.alpakka.xlsx
 
 import java.util.zip.ZipFile
-
 import akka.stream.Materializer
+import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
 import akka.stream.alpakka.xml.{Characters, EndElement, StartElement}
-import akka.stream.contrib.ZipInputStreamSource.ZipEntryData
 import akka.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
 import akka.util.ByteString
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
@@ -1,11 +1,10 @@
 package akka.stream.alpakka.xlsx
 
 import java.util.zip.ZipFile
-
 import akka.stream.Materializer
+import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
 import akka.stream.alpakka.xml.{EndElement, ParseEvent, StartElement}
-import akka.stream.contrib.ZipInputStreamSource.ZipEntryData
 import akka.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
 import akka.util.ByteString
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
@@ -2,11 +2,10 @@ package akka.stream.alpakka.xlsx
 
 import java.io.FileNotFoundException
 import java.util.zip.ZipFile
-
 import akka.stream.Materializer
+import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
 import akka.stream.alpakka.xml.javadsl.XmlParsing
 import akka.stream.alpakka.xml.{EndElement, ParseEvent, StartElement}
-import akka.stream.contrib.ZipInputStreamSource.ZipEntryData
 import akka.stream.scaladsl.{Source, StreamConverters}
 import akka.util.ByteString
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -2,13 +2,11 @@ package akka.stream.alpakka.xlsx
 
 import java.io.{FileNotFoundException, PipedInputStream, PipedOutputStream}
 import java.util.zip.{ZipFile, ZipInputStream}
-
 import akka.NotUsed
 import akka.stream.Materializer
+import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.alpakka.xml.{ Characters, EndElement, StartElement }
-import akka.stream.contrib.ZipInputStreamSource
-import akka.stream.contrib.ZipInputStreamSource.ZipEntryData
+import akka.stream.alpakka.xml.{Characters, EndElement, StartElement}
 import akka.stream.scaladsl.{Sink, Source, StreamConverters}
 import akka.util.ByteString
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -77,6 +77,7 @@ object XlsxParsing {
       sstSink: Sink[(Int, String), Future[Map[Int, String]]]
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
     val nextStepInputStream = new PipedInputStream()
+    //Don't inline! Pipe needs to be connected before reading, otherwise `java.io.IOException: Pipe not connected` is possible
     val outputStream = new PipedOutputStream(nextStepInputStream)
     source.to(StreamConverters.fromOutputStream(() => outputStream)).run()
     readFromStream(ZipInputStreamSource(() => new ZipInputStream(nextStepInputStream)), sheetType, sstSink)

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -77,7 +77,8 @@ object XlsxParsing {
       sstSink: Sink[(Int, String), Future[Map[Int, String]]]
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Source[Row, NotUsed] = {
     val nextStepInputStream = new PipedInputStream()
-    source.to(StreamConverters.fromOutputStream(() => new PipedOutputStream(nextStepInputStream))).run()
+    val outputStream = new PipedOutputStream(nextStepInputStream)
+    source.to(StreamConverters.fromOutputStream(() => outputStream)).run()
     readFromStream(ZipInputStreamSource(() => new ZipInputStream(nextStepInputStream)), sheetType, sstSink)
   }
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/ZipInputStreamSource.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/ZipInputStreamSource.scala
@@ -70,9 +70,9 @@ final class ZipInputStreamSource private (in: () => ZipInputStream,
                                           allowedZipExtensions: immutable.Seq[String])
     extends GraphStageWithMaterializedValue[SourceShape[(ZipEntryData, ByteString)], Future[Long]] {
 
-  val matValue = Promise[Long]()
+  private val matValue = Promise[Long]()
 
-  override val shape =
+  override val shape: SourceShape[(ZipEntryData, ByteString)] =
     SourceShape(Outlet[(ZipEntryData, ByteString)]("zipInputStreamSource.out"))
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Long]) = {
@@ -118,9 +118,6 @@ final class ZipInputStreamSource private (in: () => ZipInputStream,
             fillBuffer(maxBuffer)
             buffer match {
               case Seq() =>
-                finalize()
-              case head +: Seq() =>
-                push(out, head)
                 finalize()
               case head +: tail =>
                 push(out, head)

--- a/src/main/scala/akka/stream/alpakka/xlsx/ZipInputStreamSource.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/ZipInputStreamSource.scala
@@ -1,0 +1,214 @@
+package akka.stream.alpakka.xlsx
+
+import java.util.zip.{ZipEntry, ZipInputStream}
+import akka.stream.Attributes.{InputBuffer, name}
+import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
+import akka.stream.impl.Stages.DefaultAttributes.IODispatcher
+import akka.stream.scaladsl.Source
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, OutHandler}
+import akka.stream.{Attributes, Outlet, SourceShape}
+import akka.util.ByteString
+import akka.util.ByteString.ByteString1C
+
+import scala.annotation.{nowarn, tailrec}
+import scala.collection.immutable
+import scala.concurrent.{Future, Promise}
+import scala.util.control.NonFatal
+
+/**
+ * This companion defines a factory for [[ZipInputStreamSource]] instances,
+ * see [[ZipInputStreamSource.apply]].
+ */
+object ZipInputStreamSource {
+
+  final val DefaultChunkSize = 8192
+  final val DefaultAllowedZipExtensions = immutable.Seq(".zip")
+
+  /**
+   * Data type for zip entries.
+   *
+   * @param name file name
+   * @param creationTime The last modification time of the entry in milliseconds
+   *          since the epoch, or -1 if not specified
+   */
+  final case class ZipEntryData(name: String, creationTime: Long)
+
+  /**
+   * Factory for [[ZipInputStreamSource]] instances wrapped
+   * into Source.
+   *
+   * @param in a function that builds a ZipInputStream
+   * @param chunkSize the size of the chunks
+   * @param allowedZipExtensions collection of allowed extensions for zipped containers,
+   *                    as zip or jar files. Only ".zip" extension allowed by default.
+   * @return [[ZipInputStreamSource]] instance
+   */
+  def apply(
+      in: () => ZipInputStream,
+      chunkSize: Int = DefaultChunkSize,
+      allowedZipExtensions: immutable.Seq[String] = DefaultAllowedZipExtensions
+  ): Source[(ZipEntryData, ByteString), Future[Long]] =
+    Source
+      .fromGraph(new ZipInputStreamSource(in, chunkSize, allowedZipExtensions))
+      .withAttributes(name("zipInputStreamSource") and IODispatcher)
+
+}
+
+/**
+ * A stage that works as a Source of data chunks extracted from
+ * zip files. In addition to regular files, the zip file might contain
+ * directories and other zip files. Every chunk is a tuple of ZipEntryData
+ * and ByteString, where the former carries basic info about the file from
+ * which the bytes come and the latter carries those bytes. This stage
+ * materializes to the total amount of read bytes.
+ *
+ * @param in a function that builds a [[ZipInputStream]]
+ * @param chunkSize the size of the chunks
+ */
+final class ZipInputStreamSource private (in: () => ZipInputStream,
+                                          chunkSize: Int,
+                                          allowedZipExtensions: immutable.Seq[String])
+    extends GraphStageWithMaterializedValue[SourceShape[(ZipEntryData, ByteString)], Future[Long]] {
+
+  val matValue = Promise[Long]()
+
+  override val shape =
+    SourceShape(Outlet[(ZipEntryData, ByteString)]("zipInputStreamSource.out"))
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
+
+    val InputBuffer(initialBuffer, maxBuffer) =
+      inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16))
+
+    val logic = new GraphStageLogic(shape) {
+      import shape._
+
+      private var is: ZipInputStream = null
+      private var readBytesTotal: Long = 0L
+      private var buffer: Vector[(ZipEntryData, ByteString)] = Vector.empty
+      private var eof: Boolean = false
+      private var currentEntry: Option[ZipEntry] = None
+      private var currentStreams: Seq[ZipInputStream] = Seq()
+
+      override def preStart(): Unit = {
+        super.preStart()
+        try {
+          is = in()
+          currentStreams = List(is)
+          fillBuffer(initialBuffer)
+        } catch {
+          case NonFatal(ex) =>
+            matValue.failure(ex)
+            failStage(ex)
+        }
+      }
+
+      override def postStop(): Unit = {
+        if (is != null) {
+          is.close()
+        }
+        super.postStop()
+      }
+
+      setHandler(
+        out,
+        new OutHandler {
+
+          override def onPull(): Unit = {
+            fillBuffer(maxBuffer)
+            buffer match {
+              case Seq() =>
+                finalize()
+              case head +: Seq() =>
+                push(out, head)
+                finalize()
+              case head +: tail =>
+                push(out, head)
+                buffer = tail
+              case _ =>
+                //todo
+                throw new IllegalStateException("wtf")
+            }
+            def finalize() =
+              try {
+                is.close()
+              } finally {
+                matValue.success(readBytesTotal)
+                complete(out)
+              }
+          }
+
+          //todo
+          @nowarn override def onDownstreamFinish(): Unit =
+            try {
+              is.close()
+            } finally {
+              matValue.success(readBytesTotal)
+              super.onDownstreamFinish()
+            }
+        }
+      ) // end of handler
+
+      @tailrec private def nextEntry(streams: Seq[ZipInputStream]): (Option[ZipEntry], Seq[ZipInputStream]) =
+        streams match {
+          case Seq() => (None, streams)
+          case (z :: zs) =>
+            val entry = Option(z.getNextEntry)
+            entry match {
+              case None =>
+                nextEntry(zs)
+              case Some(e) if isZipFile(e) =>
+                nextEntry(new ZipInputStream(z) +: streams)
+              case Some(e) if e.isDirectory =>
+                nextEntry(streams)
+              case _ =>
+                (entry, streams)
+            }
+        }
+
+      private def isZipFile(e: ZipEntry) = {
+        val name = e.getName.toLowerCase
+        allowedZipExtensions.exists(name.endsWith)
+      }
+
+      /** BLOCKING I/O READ */
+      private def readChunk() = {
+        def read(arr: Array[Byte]) = currentStreams.headOption.flatMap { stream =>
+          val readBytes = stream.read(arr)
+          if (readBytes == -1) {
+            val (entry, streams) = nextEntry(currentStreams)
+            currentStreams = streams
+            currentEntry = entry
+            entry.map(zipEntry => {
+              (zipEntry, streams.head.read(arr))
+            })
+          } else {
+            Some((currentEntry.get, readBytes))
+          }
+        }
+        val arr = Array.ofDim[Byte](chunkSize)
+        read(arr) match {
+          case None =>
+            eof = true
+          case Some((entry, readBytes)) =>
+            readBytesTotal += readBytes
+            val entryData = ZipEntryData(entry.getName, entry.getTime)
+            val chunk =
+              if (readBytes == chunkSize)
+                ByteString1C(arr)
+              else
+                ByteString1C(arr).take(readBytes)
+            buffer :+= ((entryData, chunk))
+        }
+      } // readChunk
+
+      private def fillBuffer(size: Int) =
+        while (buffer.length < size && !eof) {
+          readChunk()
+        }
+
+    }
+
+    (logic, matValue.future)
+  }
+}

--- a/src/main/scala/akka/stream/alpakka/xlsx/ZipInputStreamSource.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/ZipInputStreamSource.scala
@@ -1,6 +1,5 @@
 package akka.stream.alpakka.xlsx
 
-import java.util.zip.{ZipEntry, ZipInputStream}
 import akka.stream.Attributes.{InputBuffer, name}
 import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
 import akka.stream.impl.Stages.DefaultAttributes.IODispatcher
@@ -10,6 +9,7 @@ import akka.stream.{Attributes, Outlet, SourceShape}
 import akka.util.ByteString
 import akka.util.ByteString.ByteString1C
 
+import java.util.zip.{ZipEntry, ZipInputStream}
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.immutable
 import scala.concurrent.{Future, Promise}

--- a/src/test/scala/akka/stream/alpakka/xlsx/BaseStreamSpec.scala
+++ b/src/test/scala/akka/stream/alpakka/xlsx/BaseStreamSpec.scala
@@ -1,0 +1,19 @@
+package akka.stream.alpakka.xlsx
+
+import akka.actor.ActorSystem
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.BeforeAndAfterAll
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+trait BaseStreamSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  protected implicit val system: ActorSystem = ActorSystem("test")
+
+  override protected def afterAll(): Unit = {
+    Await.ready(system.terminate(), 5.seconds)
+    super.afterAll()
+  }
+}

--- a/src/test/scala/akka/stream/alpakka/xlsx/ZipInputStreamSourceSpec.scala
+++ b/src/test/scala/akka/stream/alpakka/xlsx/ZipInputStreamSourceSpec.scala
@@ -1,0 +1,116 @@
+package akka.stream.alpakka.xlsx
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestDuration
+import org.scalatest.Assertion
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+class ZipInputStreamSourceSpec extends BaseStreamSpec {
+
+  "A ZipInputStreamSource" should {
+    "emit as many chunks as files when files fit on the chunks" in {
+      check(numFiles = 3)
+    }
+
+    "emit more chunks than files when files don't fit on the chunks" in {
+      check(numFiles = 3, chunkSize = 256)
+    }
+
+    "emit an extra chunk per file when the distribution is not exact" in {
+      check(numFiles = 3, chunkSize = 250)
+    }
+
+    "materialize to 0 bytes when the file is empty" in {
+      check(numFiles = 0)
+    }
+
+    "fail when the zip cannot be read and materialize to an Exception" in {
+      val (ex, probe) = ZipInputStreamSource(() => throw new Exception)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+      probe
+        .expectSubscriptionAndError()
+
+      intercept[Exception] {
+        Await.result(ex, 1.second.dilated)
+      }
+    }
+  }
+
+  private def check(numFiles: Int, fileSize: Int = 1024, chunkSize: Int = 1024): Assertion = {
+    val expectedSeq =
+      Vector.fill(numFiles)(loremIpsum.take(fileSize).toVector.grouped(chunkSize).toVector).flatten
+    val nChunksPerFile = fileSize / chunkSize + (if (fileSize % chunkSize != 0) 1 else 0)
+    val totalRequested = if (numFiles > 0) numFiles.toLong * nChunksPerFile else 1
+
+    val (totalBytesRead, probe) =
+      ZipInputStreamSource(() => new ZipInputStream(sampleZipFile(numFiles, fileSize)), chunkSize)
+        .map { case (_, bs) => bs.toVector }
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+    probe
+      .request(totalRequested)
+      .expectNextN(expectedSeq)
+      .expectComplete()
+
+    Await.result(totalBytesRead, 1.second.dilated) shouldBe (numFiles * fileSize)
+  }
+
+  private def sampleZipFile(numFiles: Int, sizePerFile: Int = 1024, dirRatio: Int = 4): ByteArrayInputStream =
+    withZos { zos =>
+      (1 to numFiles).foreach(i1 => {
+        val dirName = if (i1 > dirRatio) s"directory_${i1 / dirRatio}/" else ""
+        if (i1 > dirRatio && i1 % dirRatio == 1) {
+          zos.putNextEntry(new ZipEntry(dirName)) // New directory
+          zos.closeEntry()
+        }
+        val entryName = s"${dirName}file_$i1"
+        if (i1 % 2 != 0) {
+          zos.putNextEntry(new ZipEntry(entryName))
+          zos.write(sampleFile(sizePerFile))
+        } else { // nested zip
+          zos.putNextEntry(new ZipEntry(s"$entryName.zip"))
+          val bais = sampleZipFile(1, sizePerFile)
+          val arr = new Array[Byte](bais.available)
+          bais.read(arr)
+          zos.write(arr)
+          bais.close()
+        }
+        zos.closeEntry()
+      })
+    }
+
+  private def withZos(f: ZipOutputStream => Unit): ByteArrayInputStream = {
+    val baos = new ByteArrayOutputStream()
+    val zos = new ZipOutputStream(baos)
+    try {
+      f(zos)
+      zos.finish()
+      new ByteArrayInputStream(baos.toByteArray)
+    } finally {
+      if (zos != null)
+        zos.close()
+    }
+  }
+
+  private def sampleFile(size: Int) = loremIpsum.take(size).toArray
+
+  private def loremIpsum: LazyList[Byte] =
+    LazyList.concat("""|Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent auctor imperdiet
+         |velit, eu dapibus nisl dapibus vitae. Sed quam lacus, fringilla posuere ligula at,
+         |aliquet laoreet nulla. Aliquam id fermentum justo. Aliquam et massa consequat,
+         |pellentesque dolor nec, gravida libero. Phasellus elit eros, finibus eget
+         |sollicitudin ac, consectetur sed ante. Etiam ornare lacus blandit nisi gravida
+         |accumsan. Sed in lorem arcu. Vivamus et eleifend ligula. Maecenas ut commodo ante.
+         |Suspendisse sit amet placerat arcu, porttitor sagittis velit. Quisque gravida mi a
+         |porttitor ornare. Cras lorem nisl, sollicitudin vitae odio at, vehicula maximus
+         |mauris. Sed ac purus ac turpis pellentesque cursus ac eget est. Pellentesque
+         |habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+         |""".stripMargin.toCharArray.map(_.toByte)) #::: loremIpsum
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.8-AV6"
+version in ThisBuild := "0.0.8-AV8-SNAPSHOT"


### PR DESCRIPTION
The important part is:
```scala
    val outputStream = new PipedOutputStream(nextStepInputStream)
    source.to(StreamConverters.fromOutputStream(() => outputStream)).run()
```

Please note that I've also copied `ZipInputStreamSource` (incl. testsuite) from `akka-streams-contrib` (as recommended) and modified it cause it made me scared in a couple of places.