### PR TITLE
Pekko and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Alpakka XLSX Reader
 
-**NOT FOR PRODUCTION USE, YET**
-
-Currently this project provides a yet incomplete way of reading Excel files.
-
 Things to do:
 
 * [ ] Better XLSX file format detection

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 name := "akka-xlsx"
 
-lazy val AlpakkaXmlVersion = "3.0.3"
-lazy val AkkaTestkitVersion = "2.6.16"
-lazy val ScalatestVersion = "3.2.3"
-lazy val ScalatestPlusVersion = "3.2.3.0"
-lazy val ScalacheckVersion = "1.15.2"
+lazy val PekkoXmlVersion = "1.0.2"
+lazy val PekkoStreamVersion = "1.0.3" //fixes statefulMapConcat issue from pekko-stream 1.0.2
+lazy val PekkoTestkitVersion = "1.0.3"
+lazy val ScalatestVersion = "3.2.19"
+lazy val ScalatestPlusVersion = "3.2.19.0"
 
 lazy val commonSettings = Seq(
   updateOptions := updateOptions.value.withGigahorse(false),
-  scalaVersion := "2.13.6",
+  scalaVersion := "2.13.14",
   organization := "de.envisia.akka",
   scalacOptions ++= Seq(
     "-encoding",
@@ -18,7 +18,7 @@ lazy val commonSettings = Seq(
     "-deprecation",
     "-Xfatal-warnings",
   ),
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-o"),
+  Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-o"),
   publishMavenStyle := true,
   pomIncludeRepository := (_ => false),
 )
@@ -26,12 +26,12 @@ lazy val commonSettings = Seq(
 lazy val root = (project in file("."))
   .settings(commonSettings ++ Seq(
     libraryDependencies ++= Seq(
-      "com.lightbend.akka" %% "akka-stream-alpakka-xml" % AlpakkaXmlVersion,
+      "org.apache.pekko" %% "pekko-connectors-xml" % PekkoXmlVersion,
+      "org.apache.pekko" %% "pekko-stream" % PekkoStreamVersion,
     ) ++ Seq(
-      "com.typesafe.akka" %% "akka-stream-testkit" % AkkaTestkitVersion,
+      "org.apache.pekko" %% "pekko-stream-testkit" % PekkoTestkitVersion,
       "org.scalatest" %% "scalatest" % ScalatestVersion,
-      "org.scalatestplus" %% "scalacheck-1-15" % ScalatestPlusVersion,
-      "org.scalacheck" %% "scalacheck" % ScalacheckVersion,
+      "org.scalatestplus" %% "scalacheck-1-18" % ScalatestPlusVersion,
     ).map(_ % Test)
   ))
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 name := "akka-xlsx"
 
 lazy val PekkoXmlVersion = "1.0.2"
-lazy val PekkoStreamVersion = "1.0.3" //fixes statefulMapConcat issue from pekko-stream 1.0.2
+//Override transitive dependency to fix statefulMapConcat issue from 1.0.2.
+// Can be removed when pekko-xml 1.0.3+ is released.
+lazy val PekkoStreamVersion = "1.0.3"
 lazy val PekkoTestkitVersion = "1.0.3"
 lazy val ScalatestVersion = "3.2.19"
 lazy val ScalatestPlusVersion = "3.2.19.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty"
-sbt.version=1.4.6
+sbt.version=1.10.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 logLevel := Level.Warn
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")

--- a/src/main/scala/akka/stream/alpakka/xlsx/CellReference.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/CellReference.scala
@@ -1,9 +1,8 @@
 package akka.stream.alpakka.xlsx
 
+import org.apache.pekko.stream.connectors.xml.Attribute
+
 import java.util.Locale
-
-import akka.stream.alpakka.xml.Attribute
-
 import scala.annotation.tailrec
 import scala.util.Try
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/SstStreamer.scala
@@ -1,13 +1,13 @@
 package akka.stream.alpakka.xlsx
 
-import java.util.zip.ZipFile
-import akka.stream.Materializer
-import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
-import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.alpakka.xml.{Characters, EndElement, StartElement}
-import akka.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.connectors.xlsx.ZipInputStreamSource.ZipEntryData
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.scaladsl.XmlParsing
+import org.apache.pekko.stream.connectors.xml.{Characters, EndElement, StartElement}
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 
+import java.util.zip.ZipFile
 import scala.concurrent.{ExecutionContext, Future}
 
 object SstStreamer {

--- a/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/StyleStreamer.scala
@@ -1,13 +1,13 @@
 package akka.stream.alpakka.xlsx
 
-import java.util.zip.ZipFile
-import akka.stream.Materializer
-import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
-import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.alpakka.xml.{EndElement, ParseEvent, StartElement}
-import akka.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.connectors.xlsx.ZipInputStreamSource.ZipEntryData
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.scaladsl.XmlParsing
+import org.apache.pekko.stream.connectors.xml.{EndElement, ParseEvent, StartElement}
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 
+import java.util.zip.ZipFile
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try

--- a/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/WorkbookStreamer.scala
@@ -1,14 +1,15 @@
 package akka.stream.alpakka.xlsx
 
+
+import org.apache.pekko.connectors.xlsx.ZipInputStreamSource.ZipEntryData
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.javadsl.XmlParsing
+import org.apache.pekko.stream.connectors.xml.{EndElement, ParseEvent, StartElement}
+import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
+import org.apache.pekko.util.ByteString
+
 import java.io.FileNotFoundException
 import java.util.zip.ZipFile
-import akka.stream.Materializer
-import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
-import akka.stream.alpakka.xml.javadsl.XmlParsing
-import akka.stream.alpakka.xml.{EndElement, ParseEvent, StartElement}
-import akka.stream.scaladsl.{Source, StreamConverters}
-import akka.util.ByteString
-
 import scala.concurrent.Future
 import scala.util.Try
 

--- a/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
+++ b/src/main/scala/akka/stream/alpakka/xlsx/XlsxParsing.scala
@@ -1,15 +1,17 @@
 package akka.stream.alpakka.xlsx
 
+
+import org.apache.pekko.NotUsed
+import org.apache.pekko.connectors.xlsx.ZipInputStreamSource
+import org.apache.pekko.connectors.xlsx.ZipInputStreamSource.ZipEntryData
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.scaladsl.XmlParsing
+import org.apache.pekko.stream.connectors.xml.{Characters, EndElement, StartElement}
+import org.apache.pekko.stream.scaladsl.{Sink, Source, StreamConverters}
+import org.apache.pekko.util.ByteString
+
 import java.io.{FileNotFoundException, PipedInputStream, PipedOutputStream}
 import java.util.zip.{ZipFile, ZipInputStream}
-import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
-import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.alpakka.xml.{Characters, EndElement, StartElement}
-import akka.stream.scaladsl.{Sink, Source, StreamConverters}
-import akka.util.ByteString
-
 import scala.collection.immutable.TreeMap
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/org/apache/pekko/connectors/xlsx/ZipInputStreamSource.scala
+++ b/src/main/scala/org/apache/pekko/connectors/xlsx/ZipInputStreamSource.scala
@@ -1,13 +1,13 @@
-package akka.stream.alpakka.xlsx
+package org.apache.pekko.connectors.xlsx
 
-import akka.stream.Attributes.{InputBuffer, name}
-import akka.stream.alpakka.xlsx.ZipInputStreamSource.ZipEntryData
-import akka.stream.impl.Stages.DefaultAttributes.IODispatcher
-import akka.stream.scaladsl.Source
-import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, OutHandler}
-import akka.stream.{Attributes, Outlet, SourceShape}
-import akka.util.ByteString
-import akka.util.ByteString.ByteString1C
+import org.apache.pekko.connectors.xlsx.ZipInputStreamSource.ZipEntryData
+import org.apache.pekko.stream.Attributes.{InputBuffer, name}
+import org.apache.pekko.stream.impl.Stages.DefaultAttributes.IODispatcher
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, OutHandler}
+import org.apache.pekko.stream.{Attributes, Outlet, SourceShape}
+import org.apache.pekko.util.ByteString
+import org.apache.pekko.util.ByteString.ByteString1C
 
 import java.util.zip.{ZipEntry, ZipInputStream}
 import scala.annotation.tailrec

--- a/src/test/scala/akka/stream/alpakka/xlsx/BaseStreamSpec.scala
+++ b/src/test/scala/akka/stream/alpakka/xlsx/BaseStreamSpec.scala
@@ -1,9 +1,9 @@
 package akka.stream.alpakka.xlsx
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/akka/stream/alpakka/xlsx/CellReferenceTest.scala
+++ b/src/test/scala/akka/stream/alpakka/xlsx/CellReferenceTest.scala
@@ -1,10 +1,10 @@
 package akka.stream.alpakka.xlsx
 
-import akka.stream.alpakka.xml.Attribute
+import org.apache.pekko.stream.connectors.xml.Attribute
 import org.scalacheck.Gen
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 final class CellReferenceTest extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   "CellReference" should {

--- a/src/test/scala/akka/stream/alpakka/xlsx/ZipInputStreamSourceSpec.scala
+++ b/src/test/scala/akka/stream/alpakka/xlsx/ZipInputStreamSourceSpec.scala
@@ -1,12 +1,13 @@
 package akka.stream.alpakka.xlsx
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
-import akka.stream.scaladsl.Keep
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestDuration
+import org.apache.pekko.connectors.xlsx.ZipInputStreamSource
+import org.apache.pekko.stream.scaladsl.Keep
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko.testkit.TestDuration
 import org.scalatest.Assertion
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 

--- a/src/test/scala/demo/Main.scala
+++ b/src/test/scala/demo/Main.scala
@@ -1,18 +1,13 @@
 package demo
 
+import akka.stream.alpakka.xlsx.{Cell, XlsxParsing}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.connectors.xml._
+import org.apache.pekko.stream.scaladsl.Sink
+
 import java.nio.file.Paths
 import java.util.zip.ZipFile
-
-import akka.Done
-import akka.actor.ActorSystem
-import akka.stream.{ ActorMaterializer, Materializer }
-import akka.stream.alpakka.xml._
-import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.scaladsl.{ Sink, StreamConverters }
-import akka.stream.alpakka.xlsx._
-
-import scala.collection.mutable
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.ExecutionContext
 
 object Main {
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.8-AV9-SNAPSHOT"
+ThisBuild / version := "0.0.8-AV10-SNAPSHOT"


### PR DESCRIPTION
- Switch to from akka latest pekko 1.0.3
- Update ScalaTest to 3.2.19
- Set Scala version to 2.13.14